### PR TITLE
Bugfix: pass username and password to oauth module when obtaining credentials for non X display sessions

### DIFF
--- a/uocli/auth/oauth.py
+++ b/uocli/auth/oauth.py
@@ -10,8 +10,7 @@ import requests
 import time
 import json
 
-#HAS_GUI = 'DISPLAY' in os.environ
-HAS_GUI = True if sys.platform == 'win32' else os.environ['DISPLAY']
+HAS_GUI = True if (sys.platform == 'win32' or 'DISPLAY' in os.environ) else False
 SUPPORTED_CLIENTS = config['supported_clients']
 AUTH_SERVER_URL = config['auth_server']['url']
 

--- a/uocli/storage/session.py
+++ b/uocli/storage/session.py
@@ -59,7 +59,8 @@ def assumed_session(session=None,
 
     def refresh(username=None, password=None,
                 client_id=None, client_secret=None):
-        oauth = OAuth(client_id=client_id, client_secret=client_secret)
+        oauth = OAuth(client_id=client_id, client_secret=client_secret,
+                      username=username, password=password)
         access_token = oauth.get_tokens()["access_token"]
 
         sts_client = session.client('sts',


### PR DESCRIPTION
Fixes a bug where we were not passing username and password to the oauth module for obtaining credentials.
